### PR TITLE
Use gulp.watch() in conjunction with BrowserSync's reload() method

### DIFF
--- a/browser-sync-nodemon-expressjs/README.md
+++ b/browser-sync-nodemon-expressjs/README.md
@@ -4,7 +4,7 @@ A gulp recipe using vanilla [```browser-sync```](https://github.com/shakyShane/b
 
 With the combination of these two, we can achieve the following use-cases:
 * Inject changes into loaded page, when CSS or images are modified, without reloading the whole page.
-* Reload page when affected files are modified (HTML, partials, client-side code).
+* Reload page when affected files are modified (HTML, partials, client-side JavaScript code).
 * Restart server when core server files are modified.
 
 ## Running the example
@@ -19,13 +19,14 @@ Run ```gulp``` to start
 2. To see ```browser-sync``` + ```nodemon``` working together:
     * Edit ```public/style.css``` to see ```browser-sync``` injecting changed css into page without reloading page
     * Edit ```public/index.html``` to see ```browser-sync``` reloading browser upon change
+    * Edit ```public/main.js``` to see ```browser-sync``` reloading browser upon change
     * Edit ```app.js``` to see ```nodemon``` restarting server and ```browser-sync``` reloading page upon page
 
 ## Notes
 
 ### [BS] [ERROR] Proxy address not reachable. Is your server running?
 
-Running ```gulp``` will show the following output
+Running an older version of ```gulp``` may show the following output
 
 ```
 [03:06:27] Using gulpfile ~/sogko/gulp-recipes/expressjs-browser-sync-nodemon/gulpfile.js

--- a/browser-sync-nodemon-expressjs/gulpfile.js
+++ b/browser-sync-nodemon-expressjs/gulpfile.js
@@ -27,7 +27,7 @@ gulp.task('nodemon', function (cb) {
       // reload connected browsers after a slight delay
       setTimeout(function reload() {
         browserSync.reload({
-          stream: false   //
+          stream: false
         });
       }, BROWSER_SYNC_RELOAD_DELAY);
     });
@@ -36,10 +36,7 @@ gulp.task('nodemon', function (cb) {
 gulp.task('browser-sync', ['nodemon'], function () {
 
   // for more browser-sync config options: http://www.browsersync.io/docs/options/
-  browserSync.init({
-
-    // watch the following files; changes will be injected (css & images) or cause browser to refresh
-    files: ['public/**/*.*'],
+  browserSync({
 
     // informs browser-sync to proxy our expressjs app which would run at the following location
     proxy: 'http://localhost:3000',
@@ -53,7 +50,24 @@ gulp.task('browser-sync', ['nodemon'], function () {
   });
 });
 
+gulp.task('js',  function () {
+  return gulp.src('public/**/*.js')
+    // do stuff to JavaScript files
+    //.pipe(uglify())
+    //.pipe(gulp.dest('...'));
+});
 
-gulp.task('default', ['browser-sync']);
+gulp.task('css', function () {
+  return gulp.src('public/**/*.css')
+    .pipe(browserSync.reload({ stream: true }));
+})
 
+gulp.task('bs-reload', function () {
+  browserSync.reload();
+});
 
+gulp.task('default', ['browser-sync'], function () {
+  gulp.watch('public/**/*.js',   ['js', browserSync.reload]);
+  gulp.watch('public/**/*.css',  ['css']);
+  gulp.watch('public/**/*.html', ['bs-reload']);
+});

--- a/browser-sync-nodemon-expressjs/public/index.html
+++ b/browser-sync-nodemon-expressjs/public/index.html
@@ -8,12 +8,11 @@
 <body>
 <h1>Hello World!</h1>
 <ul>
-    <li>
-        Edit public/index.html to have browser-sync reload browser
-    </li>
-    <li>
-        Edit public/style.css to have browser-sync inject css without reloading browser
-    </li>
+    <li>Edit public/style.css to have browser-sync inject css without reloading browser
+    <li>Edit public/index.html to have browser-sync reload browser
+    <li>Edit public/main.js to have browser-sync reload browser
+    <li>Edit app.js to have nodemode relaunch server, then browser-sync reload browser
 </ul>
+<script src="main.js"></script>
 </body>
 </html>

--- a/browser-sync-nodemon-expressjs/public/main.js
+++ b/browser-sync-nodemon-expressjs/public/main.js
@@ -1,0 +1,2 @@
+console.log('a log msg from main.js');
+//console.log('a different log msg from main.js');


### PR DESCRIPTION
instead of BrowserSync's 'files' option.
This seems to be the recommended practice, see
http://www.browsersync.io/docs/gulp/ and
https://github.com/shakyShane/browser-sync/issues/154
And it also seems to notice the changes much faster.

Added main.js so people can see how changing a JavaScript file also results
in the browser getting automtically reloaded.