### PR TITLE
Change 'google chrome' to 'google-chrome'

### DIFF
--- a/browser-sync-nodemon-expressjs/gulpfile.js
+++ b/browser-sync-nodemon-expressjs/gulpfile.js
@@ -49,7 +49,7 @@ gulp.task('browser-sync', ['nodemon'], function () {
     port: 4000,
 
     // open the proxied app in chrome
-    browser: ['google chrome']
+    browser: ['google-chrome']
   });
 });
 


### PR DESCRIPTION
The commandline version of google chrome is 'google-chrome'