### PR TITLE
Remove direct call to bs.reload() in gulp.watch();

### DIFF
--- a/browser-sync-nodemon-expressjs/gulpfile.js
+++ b/browser-sync-nodemon-expressjs/gulpfile.js
@@ -67,7 +67,7 @@ gulp.task('bs-reload', function () {
 });
 
 gulp.task('default', ['browser-sync'], function () {
-  gulp.watch('public/**/*.js',   ['js', browserSync.reload]);
+  gulp.watch('public/**/*.js',   ['js', 'bs-reload']);
   gulp.watch('public/**/*.css',  ['css']);
   gulp.watch('public/**/*.html', ['bs-reload']);
 });


### PR DESCRIPTION
In Gulp 3.9.1, passing direct references to methods seems to upset the Gulp Orchestrator's glob watcher. And, this has the bonus of maintaining consistency.
